### PR TITLE
added attendance modal logic for previous appointments

### DIFF
--- a/src/components/BookAppointment.tsx
+++ b/src/components/BookAppointment.tsx
@@ -80,6 +80,7 @@ const BookAppointment: React.FC = () => {
   const { data: dateResult, call: DateAPICaller } = useFetchData<{
     date: DateType;
   }>();
+
   const { data: timeResult, call: TimeAPICaller } = useFetchData<{
     time: TimeType;
   }>();

--- a/src/components/utils/commonFunction.ts
+++ b/src/components/utils/commonFunction.ts
@@ -1,7 +1,11 @@
 import { useAppointmentContext } from "@/context/AppointmentContext";
 import { useNavigate } from "react-router-dom";
 
-export const convertISTTOUTC = (date: string, time: string, addHour?: number): string => {
+export const convertISTTOUTC = (
+  date: string,
+  time: string,
+  addHour?: number
+): string => {
   // Parse time in 12-hour format (e.g., "10:00AM")
   const timeRegex = /^(\d{1,2}):(\d{2})(AM|PM)$/;
   const match = time.match(timeRegex);
@@ -22,7 +26,9 @@ export const convertISTTOUTC = (date: string, time: string, addHour?: number): s
   }
 
   // Create Date object in local time
-  const dateTimeString = `${date}T${hour.toString().padStart(2, "0")}:${minutes}:00`;
+  const dateTimeString = `${date}T${hour
+    .toString()
+    .padStart(2, "0")}:${minutes}:00`;
   const localDate = new Date(dateTimeString);
 
   // Convert local date to UTC
@@ -34,7 +40,6 @@ export const convertISTTOUTC = (date: string, time: string, addHour?: number): s
 
   return utcDate.toISOString();
 };
-
 
 export const useBookAppointment = () => {
   const {
@@ -50,8 +55,31 @@ export const useBookAppointment = () => {
       setSelectedTherapy("");
     }
     if (selectedDoctor) {
-      setSelectedDoctor("");
+      setSelectedDoctor(null);
     }
     navigate("/user/book-appointment");
   };
+};
+
+export const parseDate = (dateString: string) => {
+  // Converts date from this format "19/03/2025 11:00AM" to a suitable format
+  const [datePart, timePart] = dateString.split(" ");
+  const [day, month, year] = datePart.split("/");
+  const [hour, minute] = timePart.slice(0, -2).split(":");
+  const ampm = timePart.slice(-2).toUpperCase();
+
+  let adjustedHour = parseInt(hour, 10);
+  if (ampm === "PM" && adjustedHour !== 12) {
+    adjustedHour += 12;
+  } else if (ampm === "AM" && adjustedHour === 12) {
+    adjustedHour = 0;
+  }
+
+  return new Date(
+    parseInt(year, 10),
+    parseInt(month, 10) - 1,
+    parseInt(day, 10),
+    adjustedHour,
+    parseInt(minute, 10)
+  );
 };

--- a/src/models/typeDefinitions.ts
+++ b/src/models/typeDefinitions.ts
@@ -62,6 +62,9 @@ export interface Cancelled extends BaseUpcoming {
 
 export interface Previous extends BaseUpcoming {
   attended: boolean;
+  attendedModalDismissed: boolean;
+  doctorRating: number;
+  absentReason: string;
 }
 
 export type Appointment = BaseUpcoming | Cancelled | Previous;


### PR DESCRIPTION
# Added the following logic:
  - If a previous appointment's attendance has not been filled, user is shown a modal to fill his/her attendance.
  - If the user closes the modal, he/she can still open it and fill it by clicking on the "Fill this appointment's attendance" text in the appointment specific modal
  - If the user says "Yes" he can fill the feedback, this feedback and attended status are stored in backend on submitting.
  - Else, he can fill the reason why he/she was absent, this reason and attended status are also stored in backend on submitting.
  - Added new fields in appointment specific modal:
    - If the user has filled the feedback that he/she attended the meet, "Doctor rating" is shown in the appointment modal
    - Else, "Absent reason" is shown in the appointment modal.

  - Added additional UI fixes